### PR TITLE
feat: AddViewController에 KeyboardMonitor 추가

### DIFF
--- a/HygrometerApp.xcodeproj/project.pbxproj
+++ b/HygrometerApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		9CD4F72B28844F4200DDC7FD /* ShadowSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CD4F72A28844F4200DDC7FD /* ShadowSet.swift */; };
 		9CD4F72E288458D600DDC7FD /* CityListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CD4F72C288458D600DDC7FD /* CityListTableViewCell.swift */; };
 		9CD4F732288458EA00DDC7FD /* WeatherListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CD4F730288458EA00DDC7FD /* WeatherListTableViewCell.swift */; };
+		9CE7E8BB288CF9AD00108CBD /* KeyboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE7E8BA288CF9AD00108CBD /* KeyboardMonitor.swift */; };
 		BA04205E288932F7004D8834 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA04205D288932F7004D8834 /* UIColor.swift */; };
 		BA0420602889331F004D8834 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA04205F2889331F004D8834 /* UIView.swift */; };
 		BA0DCBBF2887E237003C059A /* WeatherRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0DCBBE2887E237003C059A /* WeatherRequest.swift */; };
@@ -39,6 +40,7 @@
 		9CD4F72A28844F4200DDC7FD /* ShadowSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowSet.swift; sourceTree = "<group>"; };
 		9CD4F72C288458D600DDC7FD /* CityListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityListTableViewCell.swift; sourceTree = "<group>"; };
 		9CD4F730288458EA00DDC7FD /* WeatherListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherListTableViewCell.swift; sourceTree = "<group>"; };
+		9CE7E8BA288CF9AD00108CBD /* KeyboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMonitor.swift; sourceTree = "<group>"; };
 		BA04205D288932F7004D8834 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		BA04205F2889331F004D8834 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
 		BA0DCBBE2887E237003C059A /* WeatherRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherRequest.swift; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				BA3DBC542879BE14005BA6F0 /* CityViewController.swift */,
 				BA3DBC502879B553005BA6F0 /* AddViewController.swift */,
 				BA3DBC522879B562005BA6F0 /* ListViewController.swift */,
+				9CE7E8BA288CF9AD00108CBD /* KeyboardMonitor.swift */,
 				9CD4F734288458F200DDC7FD /* TableViewCells */,
 			);
 			path = ViewControllers;
@@ -251,6 +254,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9CE7E8BB288CF9AD00108CBD /* KeyboardMonitor.swift in Sources */,
 				BA3DBC3F2879B438005BA6F0 /* MainViewController.swift in Sources */,
 				BA3DBC3B2879B438005BA6F0 /* AppDelegate.swift in Sources */,
 				9C15D8F0287C5D3D00486F85 /* PrivateInfo.swift in Sources */,

--- a/HygrometerApp/Sources/ViewControllers/AddViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/AddViewController.swift
@@ -110,7 +110,7 @@ class AddViewController: UIViewController {
     }
     
     /// setTempView를 터치할 때 실행되는 함수
-    @objc func hideKeyboard() {
+    @objc private func hideKeyboard() {
         print("화면Tap감지")
         
         guard let inputStr = cityListSearchBar.searchTextField.text else { return }
@@ -261,11 +261,11 @@ extension AddViewController: UITableViewDataSource {
 //MARK: - KeyboardMonitor
 extension AddViewController {
     /// 키보드 이벤트처리
-    fileprivate func observingKeyboardEvent() { //키보드 height를 받아서 처리
-        keyboardMonitor?.$keyboardHeight.sink { height in
+    private func observingKeyboardEvent() { //키보드 height를 받아서 처리
+        keyboardMonitor?.$keyboardHeight.sink { [weak self] height in
             
             //키보드의 높이가 변할때 tempView를 띄워서 상단 터치시 dismiss처리
-            self.tempView.isHidden = height > 0 ? false : true
+            self?.tempView.isHidden = height > 0 ? false : true
  
         }.store(in: &subscriptions)
     }

--- a/HygrometerApp/Sources/ViewControllers/AddViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/AddViewController.swift
@@ -58,7 +58,7 @@ class AddViewController: UIViewController {
     lazy var tempView = UIView().then {
         let tap = UITapGestureRecognizer(target: self, action: #selector(hideKeyboard))
         $0.addGestureRecognizer(tap)
-        $0.backgroundColor = .red.withAlphaComponent(0.3)
+        $0.backgroundColor = .clear
         $0.isHidden = true
     }
     

--- a/HygrometerApp/Sources/ViewControllers/AddViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/AddViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 import Alamofire
 import SnapKit
 
@@ -16,6 +17,8 @@ class AddViewController: UIViewController {
     var weatherModel: WeatherResponse?
     var searchCityList: [Item] = []
     var searchString = ""
+    var keyboardMonitor : KeyboardMonitor?
+    var subscriptions = Set<AnyCancellable>()
     
     lazy var cityListSearchBar = UISearchBar().then {
         $0.searchTextField.delegate = self
@@ -65,6 +68,9 @@ class AddViewController: UIViewController {
         super.viewDidLoad()
         setLayout()
         setStyles()
+        keyboardMonitor = KeyboardMonitor()
+        observingKeyboardEvent()
+
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -106,7 +112,11 @@ class AddViewController: UIViewController {
     /// setTempView를 터치할 때 실행되는 함수
     @objc func hideKeyboard() {
         print("화면Tap감지")
-        self.view.endEditing(true)
+        
+        guard let inputStr = cityListSearchBar.searchTextField.text else { return }
+        print("inputStr: ",inputStr)
+        cityListSearchBar.resignFirstResponder()
+        searchLocation(searchStr: inputStr)
     }
     
     /// openWeather Main 값에 따라 String 반환
@@ -246,4 +256,19 @@ extension AddViewController: UITableViewDataSource {
         }
         return cell
     }
+}
+
+//MARK: - KeyboardMonitor
+extension AddViewController {
+    /// 키보드 이벤트처리
+    fileprivate func observingKeyboardEvent() { //키보드 height를 받아서 처리
+        keyboardMonitor?.$keyboardHeight.sink{ height in
+            
+            //키보드의 높이가 변할때 tempView를 띄워서 상단 터치시 dismiss처리
+            self.tempView.isHidden = height > 0 ? false : true
+ 
+        }.store(in: &subscriptions)
+    }
+    
+
 }

--- a/HygrometerApp/Sources/ViewControllers/AddViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/AddViewController.swift
@@ -17,7 +17,7 @@ class AddViewController: UIViewController {
     var weatherModel: WeatherResponse?
     var searchCityList: [Item] = []
     var searchString = ""
-    var keyboardMonitor : KeyboardMonitor?
+    var keyboardMonitor: KeyboardMonitor?
     var subscriptions = Set<AnyCancellable>()
     
     lazy var cityListSearchBar = UISearchBar().then {
@@ -262,7 +262,7 @@ extension AddViewController: UITableViewDataSource {
 extension AddViewController {
     /// 키보드 이벤트처리
     fileprivate func observingKeyboardEvent() { //키보드 height를 받아서 처리
-        keyboardMonitor?.$keyboardHeight.sink{ height in
+        keyboardMonitor?.$keyboardHeight.sink { height in
             
             //키보드의 높이가 변할때 tempView를 띄워서 상단 터치시 dismiss처리
             self.tempView.isHidden = height > 0 ? false : true

--- a/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
+++ b/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
@@ -13,7 +13,7 @@ final class KeyboardMonitor : ObservableObject {
     
     enum Status {
         case show, hide
-        var description : String {
+        var description: String {
             switch self {
             case .show: return "보임"
             case .hide: return "안보임"

--- a/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
+++ b/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
@@ -23,8 +23,8 @@ final class KeyboardMonitor : ObservableObject {
 
     var subscriptions = Set<AnyCancellable>()
 
-    @Published var updatedKeyboardStatusAction : Status = .hide
-    @Published var keyboardHeight : CGFloat = 0.0
+    @Published var updatedKeyboardStatusAction: Status = .hide
+    @Published var keyboardHeight: CGFloat = 0.0
 
     func keyboardMonitorNoti(noti:Notification){
         print("KeyboardMonitor - keyboardWillShowNotification: noti: \(noti)") //Here
@@ -35,35 +35,34 @@ final class KeyboardMonitor : ObservableObject {
         print("KeyboardMonitor - init() called")
         
         // 키보드가 올라올 때 이벤트가 들어옴
-        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillShowNotification) // 아래 값을 구독
-            .sink{ (noti : Notification) in
+        NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillShowNotification) // 아래 값을 구독
+            .sink { noti in
                 self.keyboardMonitorNoti(noti: noti)
                 self.updatedKeyboardStatusAction = .show
 
             }.store(in: &subscriptions)
         
         // 키보드가 내려갈 때 이벤트가 들어옴
-        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillHideNotification)
-            .sink{ (noti : Notification) in
+        NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillHideNotification)
+            .sink { noti in
                 self.keyboardMonitorNoti(noti: noti)
                 self.updatedKeyboardStatusAction = .hide
             }.store(in: &subscriptions)
 
         
         // 키보드 크기가 변경될 때 이벤트가 들어옴
-        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillChangeFrameNotification)
-            .sink{ (noti : Notification) in
+        NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillChangeFrameNotification)
+            .sink { noti in
                 self.keyboardMonitorNoti(noti: noti)
 
                 let keyboardFrame = noti.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as! CGRect
 
-//                print("KeyboardMonitor - keyboardWillChangeFrameNotification: keyboardFrame.height : ", keyboardFrame.height)
                 self.keyboardHeight = keyboardFrame.height
 
             }.store(in: &subscriptions)
         
         /// 키보드 올라온 이벤트 처리 -> 키보드 높이
-        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillShowNotification)
+        NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillShowNotification)
             .merge(with: NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillChangeFrameNotification))
             .compactMap { (noti : Notification) -> CGRect in
                 return noti.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as! CGRect
@@ -73,7 +72,7 @@ final class KeyboardMonitor : ObservableObject {
             
         
         /// 키보드 내려갈때 이벤트 처리 -> 키보드 높이
-        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillHideNotification)
+        NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillHideNotification)
             .compactMap { (noti : Notification) -> CGFloat in
                 return .zero
             }.subscribe(Subscribers.Assign(object: self, keyPath: \.keyboardHeight))

--- a/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
+++ b/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
@@ -26,20 +26,17 @@ final class KeyboardMonitor: ObservableObject {
     @Published var updatedKeyboardStatusAction: Status = .hide
     @Published var keyboardHeight: CGFloat = 0.0
 
-    func keyboardMonitorNoti(noti:Notification){
+    func keyboardMonitorNoti(noti: Notification) {
         print("KeyboardMonitor - keyboardWillShowNotification: noti: \(noti)") //Here
     }
 
-    init(){
-        
-        print("KeyboardMonitor - init() called")
-        
+    init() {
+                
         // 키보드가 올라올 때 이벤트가 들어옴
         NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillShowNotification) // 아래 값을 구독
             .sink { noti in
                 self.keyboardMonitorNoti(noti: noti)
                 self.updatedKeyboardStatusAction = .show
-
             }.store(in: &subscriptions)
         
         // 키보드가 내려갈 때 이벤트가 들어옴
@@ -54,26 +51,24 @@ final class KeyboardMonitor: ObservableObject {
         NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillChangeFrameNotification)
             .sink { noti in
                 self.keyboardMonitorNoti(noti: noti)
-
                 let keyboardFrame = noti.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as! CGRect
-
                 self.keyboardHeight = keyboardFrame.height
 
             }.store(in: &subscriptions)
         
         /// 키보드 올라온 이벤트 처리 -> 키보드 높이
         NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillShowNotification)
-            .merge(with: NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillChangeFrameNotification))
-            .compactMap { (noti : Notification) -> CGRect in
-                return noti.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as! CGRect
-            }.map{ (keyboardFrame : CGRect) -> CGFloat in
+            .merge(with: NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillChangeFrameNotification))
+            .compactMap { noti in
+                return noti.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect
+            }.map { keyboardFrame in
                 return keyboardFrame.height
             }.subscribe(Subscribers.Assign(object: self, keyPath: \.keyboardHeight))
             
         
         /// 키보드 내려갈때 이벤트 처리 -> 키보드 높이
         NotificationCenter.Publisher(center: .default, name: UIResponder.keyboardWillHideNotification)
-            .compactMap { (noti : Notification) -> CGFloat in
+            .compactMap { noti in
                 return .zero
             }.subscribe(Subscribers.Assign(object: self, keyPath: \.keyboardHeight))
 

--- a/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
+++ b/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
@@ -1,0 +1,82 @@
+//
+//  KeyboardMonitor.swift
+//  HygrometerApp
+//
+//  Created by hyeonseok on 2022/07/24.
+//
+
+import Foundation
+import Combine
+import UIKit
+
+final class KeyboardMonitor : ObservableObject {
+    
+    enum Status {
+        case show, hide
+        var description : String {
+            switch self {
+            case .show: return "보임"
+            case .hide: return "안보임"
+            }
+        }
+    }
+
+    var subscriptions = Set<AnyCancellable>()
+
+    @Published var updatedKeyboardStatusAction : Status = .hide
+    @Published var keyboardHeight : CGFloat = 0.0
+
+    func keyboardMonitorNoti(noti:Notification){
+        print("KeyboardMonitor - keyboardWillShowNotification: noti: \(noti)") //Here
+    }
+
+    init(){
+        
+        print("KeyboardMonitor - init() called")
+        
+        // 키보드가 올라올 때 이벤트가 들어옴
+        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillShowNotification) // 아래 값을 구독
+            .sink{ (noti : Notification) in
+                self.keyboardMonitorNoti(noti: noti)
+                self.updatedKeyboardStatusAction = .show
+
+            }.store(in: &subscriptions)
+        
+        // 키보드가 내려갈 때 이벤트가 들어옴
+        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillHideNotification)
+            .sink{ (noti : Notification) in
+                self.keyboardMonitorNoti(noti: noti)
+                self.updatedKeyboardStatusAction = .hide
+            }.store(in: &subscriptions)
+
+        
+        // 키보드 크기가 변경될 때 이벤트가 들어옴
+        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillChangeFrameNotification)
+            .sink{ (noti : Notification) in
+                self.keyboardMonitorNoti(noti: noti)
+
+                let keyboardFrame = noti.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as! CGRect
+
+//                print("KeyboardMonitor - keyboardWillChangeFrameNotification: keyboardFrame.height : ", keyboardFrame.height)
+                self.keyboardHeight = keyboardFrame.height
+
+            }.store(in: &subscriptions)
+        
+        /// 키보드 올라온 이벤트 처리 -> 키보드 높이
+        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillShowNotification)
+            .merge(with: NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillChangeFrameNotification))
+            .compactMap { (noti : Notification) -> CGRect in
+                return noti.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as! CGRect
+            }.map{ (keyboardFrame : CGRect) -> CGFloat in
+                return keyboardFrame.height
+            }.subscribe(Subscribers.Assign(object: self, keyPath: \.keyboardHeight))
+            
+        
+        /// 키보드 내려갈때 이벤트 처리 -> 키보드 높이
+        NotificationCenter.Publisher(center: NotificationCenter.default, name: UIResponder.keyboardWillHideNotification)
+            .compactMap { (noti : Notification) -> CGFloat in
+                return .zero
+            }.subscribe(Subscribers.Assign(object: self, keyPath: \.keyboardHeight))
+
+    }
+}

--- a/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
+++ b/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
@@ -5,7 +5,6 @@
 //  Created by hyeonseok on 2022/07/24.
 //
 
-import Foundation
 import Combine
 import UIKit
 

--- a/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
+++ b/HygrometerApp/Sources/ViewControllers/KeyboardMonitor.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 import UIKit
 
-final class KeyboardMonitor : ObservableObject {
+final class KeyboardMonitor: ObservableObject {
     
     enum Status {
         case show, hide


### PR DESCRIPTION
KeyBoard Mornotor의 역할
 - 서치바 검색시 키보드의 활성화 상태를 확인
 - 키보드활성시 상단에 tempView를 생성
 - tempView에 tapGesture를 추가
 - 추가된 동작은 키보드의 return 과 동일한 기능을 함


- 임시로 tempView의 확인을 위해 색상을 넣었습니다.-> 머지전에 색상 없애고 머지할게요
- Combine 을 사용했기때문에 import를 KeyboardMornitor, addVC에 해줘야합니다.

콤바인 등록절차
- KeyboardMonitor
  -  enum Status : 상태값생성
  - 구독설정
     @Published var updatedKeyboardStatusAction : Status = .hide
     @Published var keyboardHeight : CGFloat = 0.0
  - 노티할 함수내용
    func keyboardMonitorNoti(noti:Notification)
  -  init()
      - NotificationCenter.Publisher( 구독할 함수이름)
      - sink{
          정보를 받을 노티, 혹은 설정해둔 상태
       }.store(in: &subscriptions)  -> 구독

- AddVC (구독하는 VC에도 세팅)
- ViewdidLoad
        keyboardMonitor = KeyboardMonitor()
        observingKeyboardEvent()
- extension 생성

```

//MARK: - KeyboardMonitor
extension AddViewController {
    /// 키보드 이벤트처리
    fileprivate func observingKeyboardEvent() { //키보드 height를 받아서 처리
        keyboardMonitor?.$keyboardHeight.sink{ height in
            
            //키보드의 높이가 변할때 tempView를 띄워서 상단 터치시 dismiss처리
            self.tempView.isHidden = height > 0 ? false : true
 
        }.store(in: &subscriptions)
    }
    

}
```

