### PR TITLE
API 연동 후 각 도시 별 습도 업데이트

### DIFF
--- a/HygrometerApp.xcodeproj/project.pbxproj
+++ b/HygrometerApp.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		BA5FC6472887C9CF00A69902 /* GpsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5FC6462887C9CF00A69902 /* GpsResponse.swift */; };
 		BAA0BE58289258B50044756B /* PhraseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0BE57289258B50044756B /* PhraseModel.swift */; };
 		BAA0BE5B28926D400044756B /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0BE5A28926D400044756B /* LocationManager.swift */; };
+		BAA0BE5D28929DF80044756B /* CoordinateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0BE5C28929DF80044756B /* CoordinateRequest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -61,6 +62,7 @@
 		BA5FC6462887C9CF00A69902 /* GpsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GpsResponse.swift; sourceTree = "<group>"; };
 		BAA0BE57289258B50044756B /* PhraseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhraseModel.swift; sourceTree = "<group>"; };
 		BAA0BE5A28926D400044756B /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
+		BAA0BE5C28929DF80044756B /* CoordinateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateRequest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +107,7 @@
 		BA21D3AE2887C8C10073C422 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				BAA0BE5C28929DF80044756B /* CoordinateRequest.swift */,
 				BA21D3AA2887BE8A0073C422 /* GpsRequest.swift */,
 				BA5FC6462887C9CF00A69902 /* GpsResponse.swift */,
 				BA0DCBBE2887E237003C059A /* WeatherRequest.swift */,
@@ -295,6 +298,7 @@
 				9C15D8F3287C5D5B00486F85 /* API.swift in Sources */,
 				9CD4F72E288458D600DDC7FD /* CityListTableViewCell.swift in Sources */,
 				BA3DBC3D2879B438005BA6F0 /* SceneDelegate.swift in Sources */,
+				BAA0BE5D28929DF80044756B /* CoordinateRequest.swift in Sources */,
 				BA0420602889331F004D8834 /* UIView.swift in Sources */,
 				9CD4F732288458EA00DDC7FD /* WeatherListTableViewCell.swift in Sources */,
 			);

--- a/HygrometerApp.xcodeproj/project.pbxproj
+++ b/HygrometerApp.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		BA3DBC5B2879C349005BA6F0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = BA3DBC5A2879C349005BA6F0 /* SnapKit */; };
 		BA3DBC5E2879C36F005BA6F0 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = BA3DBC5D2879C36F005BA6F0 /* Alamofire */; };
 		BA5FC6472887C9CF00A69902 /* GpsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5FC6462887C9CF00A69902 /* GpsResponse.swift */; };
+		BAA0BE58289258B50044756B /* PhraseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0BE57289258B50044756B /* PhraseModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -59,6 +60,7 @@
 		BA3DBC522879B562005BA6F0 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
 		BA3DBC542879BE14005BA6F0 /* CityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityViewController.swift; sourceTree = "<group>"; };
 		BA5FC6462887C9CF00A69902 /* GpsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GpsResponse.swift; sourceTree = "<group>"; };
+		BAA0BE57289258B50044756B /* PhraseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhraseModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +107,7 @@
 			isa = PBXGroup;
 			children = (
 				BA21D3AA2887BE8A0073C422 /* GpsRequest.swift */,
+				BAA0BE57289258B50044756B /* PhraseModel.swift */,
 				BA5FC6462887C9CF00A69902 /* GpsResponse.swift */,
 				BA0DCBBE2887E237003C059A /* WeatherRequest.swift */,
 				BA0DCBC02887E385003C059A /* WeatherResponse.swift */,
@@ -274,6 +277,7 @@
 				BA5FC6472887C9CF00A69902 /* GpsResponse.swift in Sources */,
 				BA04205E288932F7004D8834 /* UIColor.swift in Sources */,
 				9CAAC4E7288080FC005B2136 /* UserData.swift in Sources */,
+				BAA0BE58289258B50044756B /* PhraseModel.swift in Sources */,
 				BA3DBC532879B562005BA6F0 /* ListViewController.swift in Sources */,
 				BA0DCBC12887E385003C059A /* WeatherResponse.swift in Sources */,
 				BA08A81E288EDF2500DC326E /* CityViewModel.swift in Sources */,

--- a/HygrometerApp.xcodeproj/project.pbxproj
+++ b/HygrometerApp.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		9CE7E8BB288CF9AD00108CBD /* KeyboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE7E8BA288CF9AD00108CBD /* KeyboardMonitor.swift */; };
 		BA04205E288932F7004D8834 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA04205D288932F7004D8834 /* UIColor.swift */; };
 		BA0420602889331F004D8834 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA04205F2889331F004D8834 /* UIView.swift */; };
-		BA08A81E288EDF2500DC326E /* CityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA08A81D288EDF2500DC326E /* CityViewModel.swift */; };
 		BA0DCBBF2887E237003C059A /* WeatherRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0DCBBE2887E237003C059A /* WeatherRequest.swift */; };
 		BA0DCBC12887E385003C059A /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0DCBC02887E385003C059A /* WeatherResponse.swift */; };
 		BA21D3AB2887BE8A0073C422 /* GpsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA21D3AA2887BE8A0073C422 /* GpsRequest.swift */; };
@@ -45,7 +44,6 @@
 		9CE7E8BA288CF9AD00108CBD /* KeyboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMonitor.swift; sourceTree = "<group>"; };
 		BA04205D288932F7004D8834 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		BA04205F2889331F004D8834 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
-		BA08A81D288EDF2500DC326E /* CityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityViewModel.swift; sourceTree = "<group>"; };
 		BA0DCBBE2887E237003C059A /* WeatherRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherRequest.swift; sourceTree = "<group>"; };
 		BA0DCBC02887E385003C059A /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
 		BA21D3AA2887BE8A0073C422 /* GpsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GpsRequest.swift; sourceTree = "<group>"; };
@@ -98,7 +96,6 @@
 		BA08A81C288EDF0A00DC326E /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
-				BA08A81D288EDF2500DC326E /* CityViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -280,7 +277,6 @@
 				BAA0BE58289258B50044756B /* PhraseModel.swift in Sources */,
 				BA3DBC532879B562005BA6F0 /* ListViewController.swift in Sources */,
 				BA0DCBC12887E385003C059A /* WeatherResponse.swift in Sources */,
-				BA08A81E288EDF2500DC326E /* CityViewModel.swift in Sources */,
 				BA0DCBBF2887E237003C059A /* WeatherRequest.swift in Sources */,
 				BA3DBC552879BE14005BA6F0 /* CityViewController.swift in Sources */,
 				9CD4F72B28844F4200DDC7FD /* ShadowSet.swift in Sources */,

--- a/HygrometerApp.xcodeproj/project.pbxproj
+++ b/HygrometerApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		9CE7E8BB288CF9AD00108CBD /* KeyboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE7E8BA288CF9AD00108CBD /* KeyboardMonitor.swift */; };
 		BA04205E288932F7004D8834 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA04205D288932F7004D8834 /* UIColor.swift */; };
 		BA0420602889331F004D8834 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA04205F2889331F004D8834 /* UIView.swift */; };
+		BA08A81E288EDF2500DC326E /* CityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA08A81D288EDF2500DC326E /* CityViewModel.swift */; };
 		BA0DCBBF2887E237003C059A /* WeatherRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0DCBBE2887E237003C059A /* WeatherRequest.swift */; };
 		BA0DCBC12887E385003C059A /* WeatherResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0DCBC02887E385003C059A /* WeatherResponse.swift */; };
 		BA21D3AB2887BE8A0073C422 /* GpsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA21D3AA2887BE8A0073C422 /* GpsRequest.swift */; };
@@ -43,6 +44,7 @@
 		9CE7E8BA288CF9AD00108CBD /* KeyboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMonitor.swift; sourceTree = "<group>"; };
 		BA04205D288932F7004D8834 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		BA04205F2889331F004D8834 /* UIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
+		BA08A81D288EDF2500DC326E /* CityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityViewModel.swift; sourceTree = "<group>"; };
 		BA0DCBBE2887E237003C059A /* WeatherRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherRequest.swift; sourceTree = "<group>"; };
 		BA0DCBC02887E385003C059A /* WeatherResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherResponse.swift; sourceTree = "<group>"; };
 		BA21D3AA2887BE8A0073C422 /* GpsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GpsRequest.swift; sourceTree = "<group>"; };
@@ -91,6 +93,14 @@
 			path = TableViewCells;
 			sourceTree = "<group>";
 		};
+		BA08A81C288EDF0A00DC326E /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				BA08A81D288EDF2500DC326E /* CityViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		BA21D3AE2887C8C10073C422 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -137,6 +147,7 @@
 				BA3DBC3C2879B438005BA6F0 /* SceneDelegate.swift */,
 				BA666EF3288B0FD500A779BA /* Extensions */,
 				BA21D3AE2887C8C10073C422 /* Models */,
+				BA08A81C288EDF0A00DC326E /* ViewModels */,
 				BA3DBC4F2879B4D5005BA6F0 /* ViewControllers */,
 			);
 			path = Sources;
@@ -265,6 +276,7 @@
 				9CAAC4E7288080FC005B2136 /* UserData.swift in Sources */,
 				BA3DBC532879B562005BA6F0 /* ListViewController.swift in Sources */,
 				BA0DCBC12887E385003C059A /* WeatherResponse.swift in Sources */,
+				BA08A81E288EDF2500DC326E /* CityViewModel.swift in Sources */,
 				BA0DCBBF2887E237003C059A /* WeatherRequest.swift in Sources */,
 				BA3DBC552879BE14005BA6F0 /* CityViewController.swift in Sources */,
 				9CD4F72B28844F4200DDC7FD /* ShadowSet.swift in Sources */,

--- a/HygrometerApp.xcodeproj/project.pbxproj
+++ b/HygrometerApp.xcodeproj/project.pbxproj
@@ -107,11 +107,11 @@
 			isa = PBXGroup;
 			children = (
 				BA21D3AA2887BE8A0073C422 /* GpsRequest.swift */,
-				BAA0BE57289258B50044756B /* PhraseModel.swift */,
 				BA5FC6462887C9CF00A69902 /* GpsResponse.swift */,
 				BA0DCBBE2887E237003C059A /* WeatherRequest.swift */,
 				BA0DCBC02887E385003C059A /* WeatherResponse.swift */,
 				9CAAC4E6288080FC005B2136 /* UserData.swift */,
+				BAA0BE57289258B50044756B /* PhraseModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";

--- a/HygrometerApp.xcodeproj/project.pbxproj
+++ b/HygrometerApp.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		BAA0BE58289258B50044756B /* PhraseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0BE57289258B50044756B /* PhraseModel.swift */; };
 		BAA0BE5B28926D400044756B /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0BE5A28926D400044756B /* LocationManager.swift */; };
 		BAA0BE5D28929DF80044756B /* CoordinateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0BE5C28929DF80044756B /* CoordinateRequest.swift */; };
+		BAA0BE5F2892A13A0044756B /* CoordinateResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0BE5E2892A13A0044756B /* CoordinateResponse.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -63,6 +64,7 @@
 		BAA0BE57289258B50044756B /* PhraseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhraseModel.swift; sourceTree = "<group>"; };
 		BAA0BE5A28926D400044756B /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		BAA0BE5C28929DF80044756B /* CoordinateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateRequest.swift; sourceTree = "<group>"; };
+		BAA0BE5E2892A13A0044756B /* CoordinateResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateResponse.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				BAA0BE5C28929DF80044756B /* CoordinateRequest.swift */,
+				BAA0BE5E2892A13A0044756B /* CoordinateResponse.swift */,
 				BA21D3AA2887BE8A0073C422 /* GpsRequest.swift */,
 				BA5FC6462887C9CF00A69902 /* GpsResponse.swift */,
 				BA0DCBBE2887E237003C059A /* WeatherRequest.swift */,
@@ -299,6 +302,7 @@
 				9CD4F72E288458D600DDC7FD /* CityListTableViewCell.swift in Sources */,
 				BA3DBC3D2879B438005BA6F0 /* SceneDelegate.swift in Sources */,
 				BAA0BE5D28929DF80044756B /* CoordinateRequest.swift in Sources */,
+				BAA0BE5F2892A13A0044756B /* CoordinateResponse.swift in Sources */,
 				BA0420602889331F004D8834 /* UIView.swift in Sources */,
 				9CD4F732288458EA00DDC7FD /* WeatherListTableViewCell.swift in Sources */,
 			);

--- a/HygrometerApp.xcodeproj/project.pbxproj
+++ b/HygrometerApp.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		BA3DBC5B2879C349005BA6F0 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = BA3DBC5A2879C349005BA6F0 /* SnapKit */; };
 		BA3DBC5E2879C36F005BA6F0 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = BA3DBC5D2879C36F005BA6F0 /* Alamofire */; };
 		BA5FC6472887C9CF00A69902 /* GpsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5FC6462887C9CF00A69902 /* GpsResponse.swift */; };
+		BAA0BE5B28926D400044756B /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA0BE5A28926D400044756B /* LocationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -57,6 +58,7 @@
 		BA3DBC522879B562005BA6F0 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
 		BA3DBC542879BE14005BA6F0 /* CityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CityViewController.swift; sourceTree = "<group>"; };
 		BA5FC6462887C9CF00A69902 /* GpsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GpsResponse.swift; sourceTree = "<group>"; };
+		BAA0BE5A28926D400044756B /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,6 +138,7 @@
 				BA3DBC3A2879B438005BA6F0 /* AppDelegate.swift */,
 				BA3DBC3C2879B438005BA6F0 /* SceneDelegate.swift */,
 				BA666EF3288B0FD500A779BA /* Extensions */,
+				BAA0BE5928926D320044756B /* Managers */,
 				BA21D3AE2887C8C10073C422 /* Models */,
 				BA3DBC4F2879B4D5005BA6F0 /* ViewControllers */,
 			);
@@ -172,6 +175,14 @@
 				BA04205D288932F7004D8834 /* UIColor.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		BAA0BE5928926D320044756B /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				BAA0BE5A28926D400044756B /* LocationManager.swift */,
+			);
+			path = Managers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -266,6 +277,7 @@
 				BA3DBC532879B562005BA6F0 /* ListViewController.swift in Sources */,
 				BA0DCBC12887E385003C059A /* WeatherResponse.swift in Sources */,
 				BA0DCBBF2887E237003C059A /* WeatherRequest.swift in Sources */,
+				BAA0BE5B28926D400044756B /* LocationManager.swift in Sources */,
 				BA3DBC552879BE14005BA6F0 /* CityViewController.swift in Sources */,
 				9CD4F72B28844F4200DDC7FD /* ShadowSet.swift in Sources */,
 				9C15D8F3287C5D5B00486F85 /* API.swift in Sources */,

--- a/HygrometerApp/Info.plist
+++ b/HygrometerApp/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>사용자의 위치를 받아오려고 합니다.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>사용자의 위치를 받아오려고 합니다.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/HygrometerApp/Resources/Network/API.swift
+++ b/HygrometerApp/Resources/Network/API.swift
@@ -46,11 +46,21 @@ public struct API {
             }
             .resume()
     }
+    
+    static func cityName(with model: CoordinateRequest, completion: @escaping (Result<CoordinateResponse, AFError>) -> Void) {
+        AF
+            .request(ApiType.coordinate.host, method: .get, parameters: model)
+            .responseDecodable(of: CoordinateResponse.self) {
+                completion($0.result)
+            }
+            .resume()
+    }
 }
 
 enum ApiType {
     case gps
     case weather
+    case coordinate
     
     init() {
         self = .gps
@@ -59,6 +69,7 @@ enum ApiType {
     var host: String {
         switch self {
         case .gps: return "https://api.vworld.kr/req/search?"
+        case .coordinate: return "https://api.vworld.kr/req/address?service=address&request=getAddress&type=both&simple=true&zipcode=false&"
         case .weather: return "https://api.openweathermap.org/data/2.5/weather?"
         }
     }

--- a/HygrometerApp/Sources/Managers/LocationManager.swift
+++ b/HygrometerApp/Sources/Managers/LocationManager.swift
@@ -1,4 +1,3 @@
-import Combine
 import CoreLocation
 import Foundation
 
@@ -25,7 +24,8 @@ class LocationManager: NSObject {
 extension LocationManager: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.first else { return }
-        completion?(location)
         manager.stopUpdatingLocation()
+        manager.delegate = nil
+        completion?(location)
     }
 }

--- a/HygrometerApp/Sources/Managers/LocationManager.swift
+++ b/HygrometerApp/Sources/Managers/LocationManager.swift
@@ -1,0 +1,31 @@
+import Combine
+import CoreLocation
+import Foundation
+
+
+class LocationManager: NSObject {
+    
+    private override init() { }
+    
+    static let shared = LocationManager()
+    
+    private let manager = CLLocationManager()
+    
+    private var completion: ((CLLocation) -> Void)?
+    
+    /// 사용자의 위치정보를 설정합니다.
+    public func userLocation(completion: @escaping (CLLocation) -> Void) {
+        manager.requestWhenInUseAuthorization()
+        self.completion = completion
+        manager.delegate = self
+        manager.startUpdatingLocation()
+    }
+}
+
+extension LocationManager: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.first else { return }
+        completion?(location)
+        manager.stopUpdatingLocation()
+    }
+}

--- a/HygrometerApp/Sources/Models/CoordinateRequest.swift
+++ b/HygrometerApp/Sources/Models/CoordinateRequest.swift
@@ -13,6 +13,6 @@ struct CoordinateRequest: Codable {
     }
     
     init(key: String, point: Point) {
-        self.init(key: key, point: "\(point.x)\(point.y)")
+        self.init(key: key, point: "\(point.x),\(point.y)")
     }
 }

--- a/HygrometerApp/Sources/Models/CoordinateRequest.swift
+++ b/HygrometerApp/Sources/Models/CoordinateRequest.swift
@@ -1,0 +1,18 @@
+/// 시/군/구 및 gps를 요청하기위해 필요한 파라미터 모델입니다.
+struct CoordinateRequest: Codable {
+    
+    /// API Key
+    let key: String
+    
+    /// 주소를 찾을 좌표
+    let point: String
+    
+    init(key: String, point: String) {
+        self.key = key
+        self.point = point
+    }
+    
+    init(key: String, point: Point) {
+        self.init(key: key, point: "\(point.x)\(point.y)")
+    }
+}

--- a/HygrometerApp/Sources/Models/CoordinateRequest.swift
+++ b/HygrometerApp/Sources/Models/CoordinateRequest.swift
@@ -1,4 +1,4 @@
-/// 시/군/구 및 gps를 요청하기위해 필요한 파라미터 모델입니다.
+/// 좌표계로 도시명을 요청할 때 사용하는 모델입니다.
 struct CoordinateRequest: Codable {
     
     /// API Key

--- a/HygrometerApp/Sources/Models/CoordinateResponse.swift
+++ b/HygrometerApp/Sources/Models/CoordinateResponse.swift
@@ -1,0 +1,26 @@
+/// 시/군/구 및 gps를 요청하기위해 필요한 파라미터 모델입니다.
+struct CoordinateResponse: Codable {
+    let response: CRResponse
+}
+// MARK: - Response
+struct CRResponse: Codable {
+    let result: [CRResult]
+}
+
+struct CRResult: Codable {
+    let structure: CRStructure
+}
+
+
+struct CRStructure: Codable {
+    /// 시/도
+    let country: String
+    
+    /// 시/군/구
+    let city: String
+    
+    enum CodingKeys: String, CodingKey {
+        case country = "level1"
+        case city = "level2"
+    }
+}

--- a/HygrometerApp/Sources/Models/CoordinateResponse.swift
+++ b/HygrometerApp/Sources/Models/CoordinateResponse.swift
@@ -1,4 +1,4 @@
-/// 시/군/구 및 gps를 요청하기위해 필요한 파라미터 모델입니다.
+/// 도시이름을 반환하는 모델입니다.
 struct CoordinateResponse: Codable {
     let response: CRResponse
 }

--- a/HygrometerApp/Sources/Models/PhraseModel.swift
+++ b/HygrometerApp/Sources/Models/PhraseModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+
+/// 습도에 따른 문구를 보여주기 위한 모델
+enum PhraseModel {
+    case dry
+    case normal
+    case humid
+    
+    var phrase: [String] {
+        switch self {
+        case .dry:
+            return ["물을 많이 마시는 게 좋아요", "알로에 사오셨나요? 피부에 양보하세요", "목을 축이세요", "오아시스 있나요?"]
+        case .normal:
+            return ["오늘은 적당하네요"]
+        case .humid:
+            return ["너무 습하네요. 제습제가 필요해요", "비왔었나요? 물먹는 하마가 그립네요"]
+        }
+    }
+}

--- a/HygrometerApp/Sources/Models/PhraseModel.swift
+++ b/HygrometerApp/Sources/Models/PhraseModel.swift
@@ -7,6 +7,19 @@ enum PhraseModel {
     case normal
     case humid
     
+    init?(humidity: Int) {
+        switch humidity {
+        case 0...30:
+            self = .dry
+        case 31...60:
+            self = .normal
+        case 61...:
+            self = .humid
+        default:
+            return nil
+        }
+    }
+    
     var phrase: [String] {
         switch self {
         case .dry:

--- a/HygrometerApp/Sources/ViewControllers/CityViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/CityViewController.swift
@@ -73,6 +73,26 @@ class CityViewController: UIViewController {
     }
     
     func configure(with model: UserDataModel) {
+        cityTitleLabel.text = model.city
         
+        let requestModel = WeatherRequest(
+            lat: model.point.y,
+            lon: model.point.x,
+            appID: Private.weatherSecretKey,
+            lang: "ko"
+        )
+        API.weatherInformation(with: requestModel) { [weak self] in
+            switch $0 {
+            case .success(let result):
+                self?.humidityLabel.text = "\(result.main.humidity)%"
+                
+                // 습도별 문구 아무 거나 선택해서 보여줌
+                if let phrase = PhraseModel(humidity: result.main.humidity)?.phrase.randomElement() {
+                    self?.phraseLabel.text = phrase
+                }
+            case .failure(let error):
+                print(error)
+            }
+        }
     }
 }

--- a/HygrometerApp/Sources/ViewControllers/CityViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/CityViewController.swift
@@ -84,17 +84,14 @@ final class CityViewController: UIViewController {
             lang: "ko"
         )
         API.weatherInformation(with: requestModel) { [weak self] in
-            switch $0 {
-            case .success(let result):
-                self?.humidityLabel.text = "\(result.main.humidity)%"
-                
-                // 습도별 문구 아무 거나 선택해서 보여줌
-                if let phrase = PhraseModel(humidity: result.main.humidity)?.phrase.randomElement() {
-                    self?.phraseLabel.text = phrase
-                }
-            case .failure(let error):
-                print(error)
+            guard case let .success(result) = $0,
+                  let phrase = PhraseModel(humidity: result.main.humidity)?.phrase.randomElement()
+            else {
+                return
             }
+            self?.humidityLabel.text = "\(result.main.humidity)%"
+            // 습도별 문구 아무 거나 선택해서 보여줌
+            self?.phraseLabel.text = phrase
         }
     }
 }

--- a/HygrometerApp/Sources/ViewControllers/CityViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/CityViewController.swift
@@ -19,6 +19,7 @@ final class CityViewController: UIViewController {
         $0.textAlignment = .center
         $0.text = "서울"
         $0.font = .systemFont(ofSize: 30)
+        $0.adjustsFontSizeToFitWidth = true
     }
     
     /// 습도(%)를 표시해주는 label 입니다.
@@ -34,6 +35,7 @@ final class CityViewController: UIViewController {
         $0.textAlignment = .center
         $0.text = "목을 축이세요"
         $0.font = .systemFont(ofSize: 20, weight: .semibold)
+        $0.adjustsFontSizeToFitWidth = true
     }
     
     

--- a/HygrometerApp/Sources/ViewControllers/CityViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/CityViewController.swift
@@ -71,4 +71,8 @@ class CityViewController: UIViewController {
             make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
         }
     }
+    
+    func configure(with model: UserDataModel) {
+        
+    }
 }

--- a/HygrometerApp/Sources/ViewControllers/CityViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/CityViewController.swift
@@ -70,7 +70,7 @@ final class CityViewController: UIViewController {
     private func setupConstraints() {
         containerView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(56)
-            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(80)
         }
     }
     

--- a/HygrometerApp/Sources/ViewControllers/CityViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/CityViewController.swift
@@ -14,6 +14,8 @@ final class CityViewController: UIViewController {
     
     // MARK: - Properties
     
+    public private(set) var id: String = ""
+    
     /// 도시 이름을 표시해주는 label 입니다.
     private lazy var cityTitleLabel = UILabel().then {
         $0.textAlignment = .center
@@ -76,6 +78,7 @@ final class CityViewController: UIViewController {
     
     func configure(with model: UserDataModel) {
         cityTitleLabel.text = model.city
+        id = model.id
         
         let requestModel = WeatherRequest(
             lat: model.point.y,

--- a/HygrometerApp/Sources/ViewControllers/CityViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/CityViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-class CityViewController: UIViewController {
+final class CityViewController: UIViewController {
     
     // MARK: - Properties
     

--- a/HygrometerApp/Sources/ViewControllers/CityViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/CityViewController.swift
@@ -18,7 +18,7 @@ class CityViewController: UIViewController {
     private lazy var cityTitleLabel = UILabel().then {
         $0.textAlignment = .center
         $0.text = "서울"
-        $0.font = .systemFont(ofSize: 34)
+        $0.font = .systemFont(ofSize: 30)
     }
     
     /// 습도(%)를 표시해주는 label 입니다.
@@ -32,7 +32,7 @@ class CityViewController: UIViewController {
     /// 습도에 따른 문구를 표시해주는 label 입니다.
     private lazy var phraseLabel = UILabel().then {
         $0.textAlignment = .center
-        $0.text = "물을 축이세요"
+        $0.text = "목을 축이세요"
         $0.font = .systemFont(ofSize: 20, weight: .semibold)
     }
     

--- a/HygrometerApp/Sources/ViewControllers/MainViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/MainViewController.swift
@@ -45,10 +45,10 @@ final class MainViewController: UIViewController {
         $0.currentPage = 0
     }
     
-    private let dataViewControllers = [UIViewController]().with {
-        for _ in 0..<2 {
+    private var dataViewControllers = [UIViewController]().with { array in
+        UserData.shared.items.forEach { model in
             let vc = CityViewController()
-            $0.append(vc)
+            array.append(vc)
         }
     }
     

--- a/HygrometerApp/Sources/ViewControllers/MainViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/MainViewController.swift
@@ -63,6 +63,11 @@ final class MainViewController: UIViewController {
         setupLocations()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        reloadPages()
+    }
+    
     // MARK: - Configuration
     
     /// view에 올려놓을 프로퍼티를 설정합니다. `addSubview` 메서드를 여기에 작성합니다.
@@ -130,6 +135,19 @@ final class MainViewController: UIViewController {
                 self?.dataViewControllers.insert(vc, at: 0)
                 self?.pageViewController.setViewControllers([vc], direction: .forward, animated: false)
             }
+        }
+    }
+    
+    private func reloadPages() {
+        let models = UserData.shared.items
+        control.numberOfPages = models.count + 1
+        guard let vcs = dataViewControllers as? [CityViewController] else { return }
+        // models의 id가 dataViewControllers의 id에 있는지 확인 후 없으면 추가
+        models.forEach { model in
+            guard vcs.first(where: { $0.id == model.id }) == nil else { return }
+            let vc = CityViewController()
+            vc.configure(with: model)
+            dataViewControllers.append(vc)
         }
     }
     

--- a/HygrometerApp/Sources/ViewControllers/MainViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/MainViewController.swift
@@ -103,12 +103,12 @@ final class MainViewController: UIViewController {
     
     // MARK: - objc Function
     
-    @objc func listButtonDidTap() {
+    @objc private func listButtonDidTap() {
         let vc = ListViewController()
         navigationController?.pushViewController(vc, animated: true)
     }
     
-    @objc func plusButtonDidTap() {
+    @objc private func plusButtonDidTap() {
         let vc = AddViewController()
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/HygrometerApp/Sources/ViewControllers/MainViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/MainViewController.swift
@@ -43,6 +43,7 @@ final class MainViewController: UIViewController {
         $0.backgroundColor = .label.withAlphaComponent(0.3)
         $0.numberOfPages = dataViewControllers.count + 1
         $0.currentPage = 0
+        $0.setIndicatorImage(UIImage(systemName: "location.fill"), forPage: 0)
     }
     
     private var dataViewControllers = [UIViewController]().with { array in

--- a/HygrometerApp/Sources/ViewControllers/MainViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/MainViewController.swift
@@ -48,6 +48,7 @@ final class MainViewController: UIViewController {
     private var dataViewControllers = [UIViewController]().with { array in
         UserData.shared.items.forEach { model in
             let vc = CityViewController()
+            vc.configure(with: model)
             array.append(vc)
         }
     }

--- a/HygrometerApp/Sources/ViewControllers/MainViewController.swift
+++ b/HygrometerApp/Sources/ViewControllers/MainViewController.swift
@@ -20,7 +20,6 @@ final class MainViewController: UIViewController {
         transitionStyle: .scroll,
         navigationOrientation: .horizontal
     ).then {
-        $0.setViewControllers([dataViewControllers[0]], direction: .forward, animated: true)
         $0.dataSource = self
         $0.delegate = self
     }

--- a/HygrometerApp/Sources/ViewModels/CityViewModel.swift
+++ b/HygrometerApp/Sources/ViewModels/CityViewModel.swift
@@ -1,5 +1,0 @@
-struct CityViewModel {
-    let city: String
-    let humidity: Int
-    let phase: String
-}

--- a/HygrometerApp/Sources/ViewModels/CityViewModel.swift
+++ b/HygrometerApp/Sources/ViewModels/CityViewModel.swift
@@ -1,0 +1,5 @@
+struct CityViewModel {
+    let city: String
+    let humidity: Int
+    let phase: String
+}


### PR DESCRIPTION
> PR body가 커져버렸습니다. 죄송합니다 🙏

## 구현 사항 ✨

### API

- 좌표를 갖고 도시명을 갖고 오는 함수 구현
   - CoordinateRequest, CoordinateResponse 이용

### CoreLocation

- 사용자에게 GPS 접근권한을 이용하는 `LocationManager` 클래스 추가
- MainVC의 첫 페이지는 사용자의 좌표를 갖는 도시의 습도 정보 표시

### API matching

- 시작할 때 API 결괏값을 가지고 각 도시의 정보 갱신
   - `PhraseModel`을 추가하여 일정 습도에 따라 문구를 보여줄 수 있도록 설정

#### PhraseModel

- API로 받은 습도값에 따라 문구를 지정해주는 Model


## 변경 사항 📝

- 클래스 내부에서 사용하는 코드는 전부 `private`로 설정
- 상속하지 않는 클래스는 전부 `final` 설정
-`CityVC`에서 문구가 길면 너비에 따라 전체가 보일 수 있도록 폰트 조절

## Screenshots 📸

![Simulator Screen Recording - iPhone 13 Pro - 2022-07-29 at 14 51 33](https://user-images.githubusercontent.com/57972338/181691847-6ad56f45-593d-41cc-b801-22e847a196c1.gif)